### PR TITLE
SW-931 Fix: QRCode Memory leak issue & add ms in qr timestamp

### DIFF
--- a/subprojects/gst-plugins-bad/ext/qroverlay/gstbaseqroverlay.c
+++ b/subprojects/gst-plugins-bad/ext/qroverlay/gstbaseqroverlay.c
@@ -197,6 +197,7 @@ draw_overlay (GstBaseQROverlay * self, QRcode * qrcode)
 
   rect = gst_video_overlay_rectangle_new_raw (buf, x, y,
       info.width, info.height, GST_VIDEO_OVERLAY_FORMAT_FLAG_NONE);
+  gst_buffer_unref (buf);
   comp = gst_video_overlay_composition_new (rect);
   gst_video_overlay_rectangle_unref (rect);
 
@@ -241,6 +242,7 @@ gst_base_qr_overlay_draw_cb (GstBaseQROverlay * self, GstSample * sample,
       overlay = draw_overlay (GST_BASE_QR_OVERLAY (self), qrcode);
       gst_mini_object_replace (((GstMiniObject **) & priv->prev_overlay),
           (GstMiniObject *) overlay);
+      QRcode_free (qrcode);
     } else {
       GST_WARNING_OBJECT (self, "Could not encode content: %s", content);
     }

--- a/subprojects/gst-plugins-bad/ext/qroverlay/gstqroverlay.c
+++ b/subprojects/gst-plugins-bad/ext/qroverlay/gstqroverlay.c
@@ -78,7 +78,8 @@ get_qrcode_content (GstBaseQROverlay * base, GstBuffer * buf,
 
   GST_OBJECT_LOCK (self);
   content = g_strdup (self->data);
-  *reuse_prev = self->data_changed;
+  *reuse_prev = !self->data_changed;
+  self->data_changed = FALSE;
   GST_OBJECT_UNLOCK (self);
 
   return content;

--- a/subprojects/gst-plugins-base/ext/pango/gstclockoverlay.c
+++ b/subprojects/gst-plugins-base/ext/pango/gstclockoverlay.c
@@ -55,7 +55,7 @@
 #include "gstclockoverlay.h"
 #include "gstpangoelements.h"
 
-#define DEFAULT_PROP_TIMEFORMAT 	"%H:%M:%S"
+#define DEFAULT_PROP_TIMEFORMAT 	"%H:%M:%S:%MS"
 
 enum
 {
@@ -102,7 +102,7 @@ gst_clock_overlay_render_time (GstClockOverlay * overlay)
 #endif
 
   if (t == NULL)
-    return g_strdup ("--:--:--");
+    return g_strdup ("--:--:--:--");
 
 #ifdef G_OS_WIN32
   if (wcsftime (buf, sizeof (buf), (wchar_t *) overlay->wformat, t) == 0)
@@ -210,7 +210,7 @@ gst_clock_overlay_init (GstClockOverlay * overlay)
 
 #ifdef G_OS_WIN32
   overlay->wformat =
-      g_utf8_to_utf16 (DEFAULT_PROP_TIMEFORMAT, -1, NULL, NULL, NULL);
+      g_utf8_to_utf16 (DEFAULT_PROP_TIMEFORMAT, -1, NULL, NULL, NULL, NULL);
 #endif
 
   context = textoverlay->pango_context;


### PR DESCRIPTION
This PR fixes the memory leak issue we get when we use qrcodeoverlay plugin on the pipeline.